### PR TITLE
raise specific UnsupportedMediaException exception in case of http st…

### DIFF
--- a/media_platform/exception/unsupported_media_exception.py
+++ b/media_platform/exception/unsupported_media_exception.py
@@ -1,0 +1,5 @@
+from media_platform.exception.media_platform_exception import MediaPlatformException
+
+
+class UnsupportedMediaException(MediaPlatformException):
+    pass

--- a/media_platform/http_client/response_processor.py
+++ b/media_platform/http_client/response_processor.py
@@ -8,6 +8,7 @@ from media_platform.exception.forbidden_exception import ForbiddenException
 from media_platform.exception.media_platform_exception import MediaPlatformException
 from media_platform.exception.not_found_exception import NotFoundException
 from media_platform.exception.unauthorized_exception import UnauthorizedException
+from media_platform.exception.unsupported_media_exception import UnsupportedMediaException
 from media_platform.service.rest_result import RestResult
 
 
@@ -59,6 +60,9 @@ class ResponseProcessor:
 
         elif response.status_code == 409:
             raise ConflictException(message)
+
+        elif response.status_code == 415:
+            raise UnsupportedMediaException(message)
 
         elif response.status_code == 500:
             raise ServerErrorException(message)

--- a/tests/http_client/test_authenticated_http_client.py
+++ b/tests/http_client/test_authenticated_http_client.py
@@ -12,6 +12,7 @@ from media_platform.exception.media_platform_exception import MediaPlatformExcep
 from media_platform.exception.not_found_exception import NotFoundException
 from media_platform.exception.server_error_exception import ServerErrorException
 from media_platform.exception.unauthorized_exception import UnauthorizedException
+from media_platform.exception.unsupported_media_exception import UnsupportedMediaException
 from media_platform.http_client.authenticated_http_client import AuthenticatedHTTPClient
 from media_platform.service.rest_result import RestResult
 from tests.http_client.dummy_payload import DummyPayload
@@ -109,6 +110,17 @@ class TestAuthenticatedHTTPClient(unittest.TestCase):
         )
 
         with self.assertRaises(ConflictException):
+            self.authenticated_http_client.get(self.test_endpoint)
+
+    @httpretty.activate
+    def test_get_415(self):
+        httpretty.register_uri(
+            httpretty.GET,
+            self.test_endpoint,
+            status=415
+        )
+
+        with self.assertRaises(UnsupportedMediaException):
             self.authenticated_http_client.get(self.test_endpoint)
 
     @httpretty.activate


### PR DESCRIPTION
…atus 415 (metadata/extract - 'failed to extract metadata' error)

https://console.cloud.google.com/logs/query;query=logName%3D%22projects%2Fwixmp-cdfc384f15841aaa5eab16b1%2Flogs%2Fappengine.googleapis.com%252Frequest_log%22%0AprotoPayload.status%3D415;cursorTimestamp=2021-04-26T13:04:46.438747Z?project=wixmp-cdfc384f15841aaa5eab16b1